### PR TITLE
Quarto docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,4 @@ jobs:
         #token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         files: ./coverage.xml
+        


### PR DESCRIPTION
- [x] fix syntax error prevent the documentation deployment workflow from running.
